### PR TITLE
Federate other domains

### DIFF
--- a/scripts/controllers/appController.js
+++ b/scripts/controllers/appController.js
@@ -3,13 +3,11 @@ stellarExplorer.controller('appController', function($scope, $q, requestHelper, 
 
   $scope.testConfig = {
     network: websocketProtocol + '//test.stellar.org:9001',
-    txt: 'stellar-stg.stellar.org',
     domain: 'stg.stellar.org'
   };
 
   $scope.liveConfig = {
     network: websocketProtocol + '//live.stellar.org:9001',
-    txt: 'stellar.stellar.org',
     domain: 'stellar.org'
   };
 
@@ -187,7 +185,7 @@ stellarExplorer.controller('appController', function($scope, $q, requestHelper, 
     if (validAddress) {
       $scope.address = $scope.query;
 
-      reverseFederation.check_address($scope.address, $scope.config.txt, $scope.config.domain)
+      reverseFederation.check_address($scope.address, $scope.config.domain)
         .then(function (result) {
           $scope.lastQuery = result.destination + '@' + result.domain;
           deferred.resolve();
@@ -196,7 +194,7 @@ stellarExplorer.controller('appController', function($scope, $q, requestHelper, 
           deferred.resolve();
         });
     } else {
-      federation.check_email($scope.query, $scope.config.txt, $scope.config.domain)
+      federation.check_email($scope.query, $scope.config.domain)
         .then(function (result) {
           $scope.lastQuery = result.destination + '@' + result.domain;
           $scope.address = result.destination_address;

--- a/scripts/services/federation.js
+++ b/scripts/services/federation.js
@@ -3,7 +3,7 @@ stellarExplorer.factory('federation', ['$q', '$rootScope', '$http', 'stellarTxt'
 
   var cache = {};
 
-  function check_email(email, txtAddress, defaultDomain) {
+  function check_email(email, defaultDomain) {
     if (email.indexOf('@') == -1) {
       email = email + '@' + defaultDomain;
     }
@@ -19,7 +19,7 @@ stellarExplorer.factory('federation', ['$q', '$rootScope', '$http', 'stellarTxt'
       return federationPromise.promise;
     }
 
-    var txtPromise = $txt.get(txtAddress);
+    var txtPromise = $txt.get(domain);
 
     if (txtPromise) {
       if ("function" === typeof txtPromise.then) {

--- a/scripts/services/reverseFederation.js
+++ b/scripts/services/reverseFederation.js
@@ -3,7 +3,7 @@ stellarExplorer.factory('reverseFederation', ['$q', '$rootScope', '$http', 'stel
 
     var cache = {};
 
-    function check_address(address, txtAddress, defaultDomain) {
+    function check_address(address, defaultDomain) {
         var reverseFederationPromise = $q.defer();
 
         var domain = defaultDomain;
@@ -13,7 +13,7 @@ stellarExplorer.factory('reverseFederation', ['$q', '$rootScope', '$http', 'stel
           return reverseFederationPromise.promise;
         }
 
-        var txtPromise = $txt.get(txtAddress);
+        var txtPromise = $txt.get(domain);
 
         if (txtPromise) {
             if ("function" === typeof txtPromise.then) {


### PR DESCRIPTION
Remove the now unused rootAddress.
Remove the hard coded txtAddress to allow federating to arbitrary domains.
